### PR TITLE
Respect filtered languages when fetching translations

### DIFF
--- a/jelyk-word-plugin.php
+++ b/jelyk-word-plugin.php
@@ -1163,7 +1163,7 @@ JS;
 
         $translations = [];
         if ( $card_ids ) {
-            $langs = self::DEFAULT_LANGS; // only defaults (DE handled separately)
+            $langs = self::get_default_langs(); // only defaults (DE handled separately)
             $cph   = implode( ',', array_fill( 0, count( $card_ids ), '%d' ) );
             $lph   = implode( ',', array_fill( 0, count( $langs ), '%s' ) );
 


### PR DESCRIPTION
## Summary
- use the filtered default languages list when loading translations for cards

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b1874fa00832eab3fb1a3cccfe6e9)