### PR TITLE
Fix: Scope frontend CSS to .jelyk-word-block (Issue #3)

### DIFF
--- a/assets/jelyk-word-admin.css
+++ b/assets/jelyk-word-admin.css
@@ -1,18 +1,20 @@
-.jelyk-meaning, .jelyk-card { background:#fff; border:1px solid #dcdcde; border-radius:8px; padding:12px; margin:12px 0; }
-.jelyk-meaning-head { display:flex; justify-content:space-between; align-items:center; gap:12px; }
-.jelyk-meaning-title { font-weight:700; font-size:14px; }
-.jelyk-row { display:flex; gap:12px; flex-wrap:wrap; margin-top:10px; }
-.jelyk-col { flex:1 1 320px; min-width:260px; }
-.jelyk-col label { display:block; font-weight:600; margin-bottom:6px; }
-.jelyk-col input[type="text"], .jelyk-col textarea { width:100%; }
-.jelyk-cards-wrap { margin-top:10px; }
-.jelyk-card-head { display:flex; justify-content:space-between; align-items:center; gap:10px; }
-.jelyk-card-head strong { font-size:13px; }
-.jelyk-actions a.button-link-delete { color:#b32d2e; }
-.jelyk-image-preview img { border-radius:6px; border:1px solid #e5e5e5; }
-.jelyk-translations { display:none; margin-top:10px; padding:10px; background:#f6f7f7; border-radius:8px; border:1px dashed #c3c4c7; }
-.jelyk-translations .jelyk-trans-row { display:flex; gap:10px; align-items:center; margin:6px 0; }
-.jelyk-translations .jelyk-trans-row code { min-width:44px; display:inline-block; }
-.jelyk-meaning-translations { margin-top:8px; }
-.jelyk-meaning-translations summary { cursor:pointer; font-weight:600; }
-.jelyk-admin-translation-box { margin-top:8px; padding:10px; background:#f8f9fa; border:1px solid #dcdcde; border-radius:8px; }
+#jelyk_meanings_cards .jelyk-meaning,
+#jelyk_meanings_cards .jelyk-card { background:#fff; border:1px solid #dcdcde; border-radius:8px; padding:12px; margin:12px 0; }
+#jelyk_meanings_cards .jelyk-meaning-head { display:flex; justify-content:space-between; align-items:center; gap:12px; }
+#jelyk_meanings_cards .jelyk-meaning-title { font-weight:700; font-size:14px; }
+#jelyk_meanings_cards .jelyk-row { display:flex; gap:12px; flex-wrap:wrap; margin-top:10px; }
+#jelyk_meanings_cards .jelyk-col { flex:1 1 320px; min-width:260px; }
+#jelyk_meanings_cards .jelyk-col label { display:block; font-weight:600; margin-bottom:6px; }
+#jelyk_meanings_cards .jelyk-col input[type="text"],
+#jelyk_meanings_cards .jelyk-col textarea { width:100%; }
+#jelyk_meanings_cards .jelyk-cards-wrap { margin-top:10px; }
+#jelyk_meanings_cards .jelyk-card-head { display:flex; justify-content:space-between; align-items:center; gap:10px; }
+#jelyk_meanings_cards .jelyk-card-head strong { font-size:13px; }
+#jelyk_meanings_cards .jelyk-actions a.button-link-delete { color:#b32d2e; }
+#jelyk_meanings_cards .jelyk-image-preview img { border-radius:6px; border:1px solid #e5e5e5; }
+#jelyk_meanings_cards .jelyk-translations { display:none; margin-top:10px; padding:10px; background:#f6f7f7; border-radius:8px; border:1px dashed #c3c4c7; }
+#jelyk_meanings_cards .jelyk-translations .jelyk-trans-row { display:flex; gap:10px; align-items:center; margin:6px 0; }
+#jelyk_meanings_cards .jelyk-translations .jelyk-trans-row code { min-width:44px; display:inline-block; }
+#jelyk_meanings_cards .jelyk-meaning-translations { margin-top:8px; }
+#jelyk_meanings_cards .jelyk-meaning-translations summary { cursor:pointer; font-weight:600; }
+#jelyk_meanings_cards .jelyk-admin-translation-box { margin-top:8px; padding:10px; background:#f8f9fa; border:1px solid #dcdcde; border-radius:8px; }

--- a/jelyk-word-plugin.php
+++ b/jelyk-word-plugin.php
@@ -1062,8 +1062,13 @@ class Jelyk_Word_Plugin {
 	}
 
     public static function frontend_assets() {
-        // Load only on single posts.
+        // Load only on single post pages where the plugin can render.
         if ( is_admin() || ! is_singular( 'post' ) ) {
+            return;
+        }
+
+        $post_id = (int) get_queried_object_id();
+        if ( $post_id <= 0 || ! self::post_has_meanings( $post_id ) ) {
             return;
         }
 
@@ -1073,33 +1078,37 @@ class Jelyk_Word_Plugin {
 
         $css = <<<'CSS'
 .jelyk-word-block{margin-top:2.25rem;padding-top:1.25rem;border-top:1px solid rgba(0,0,0,.1)}
-.jelyk-langbar{display:flex;gap:.75rem;align-items:center;margin:0 0 1rem 0}
-.jelyk-langbar label{font-weight:600}
-.jelyk-langbar select{max-width:260px}
-.jelyk-word-meta{margin:0 0 1rem 0}
-.jelyk-kv-label{opacity:.75}
-.jelyk-meaning{margin:1.75rem 0 0 0;padding:0}
-.jelyk-meaning-title{margin:0 0 .35rem 0;font-weight:700}
-.jelyk-meaning-gloss{margin:0 0 .75rem 0;font-size:1.05em}
-.jelyk-meaning-tr{display:none;margin:.1rem 0 .6rem 0;font-size:1.02em;opacity:.92}
-.jelyk-hr{border:0;border-top:1px solid rgba(0,0,0,.12);margin:.75rem 0 1rem 0}
-.jelyk-row{margin:0 0 1rem 0}
-.jelyk-row-title{font-weight:700;margin:0 0 .35rem 0}
-.jelyk-tokens{display:flex;flex-wrap:wrap;gap:.35rem .45rem}
-.jelyk-token{display:inline-flex;align-items:center;padding:.18rem .5rem;border:1px solid rgba(0,0,0,.15);border-radius:.4rem;text-decoration:none;line-height:1.2}
-.jelyk-token:hover{text-decoration:none;border-color:rgba(0,0,0,.3)}
-.jelyk-token--plain{cursor:default}
-.jelyk-cards-title{font-weight:700;margin:0 0 .65rem 0}
-.jelyk-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem}
-.jelyk-card{background:#fff;border:1px solid rgba(0,0,0,.12);border-radius:.6rem;overflow:hidden}
-.jelyk-card figure{margin:0}
-.jelyk-card img{width:100%;height:auto;display:block}
-.jelyk-card-body{padding:.75rem .85rem}
-.jelyk-card-de{margin:0;font-weight:600}
-.jelyk-card-tr-wrap{margin:.45rem 0 0 0;font-size:.95em;opacity:.9}
-.jelyk-card-tr{display:none;margin:0}
-.jelyk-note{margin:.25rem 0 0 0;opacity:.85}
+.jelyk-word-block .jelyk-langbar{display:flex;gap:.75rem;align-items:center;margin:0 0 1rem 0}
+.jelyk-word-block .jelyk-langbar label{font-weight:600}
+.jelyk-word-block .jelyk-langbar select{max-width:260px}
+.jelyk-word-block .jelyk-word-meta{margin:0 0 1rem 0}
+.jelyk-word-block .jelyk-kv-label{opacity:.75}
+.jelyk-word-block .jelyk-meaning{margin:1.75rem 0 0 0;padding:0}
+.jelyk-word-block .jelyk-meaning-title{margin:0 0 .35rem 0;font-weight:700}
+.jelyk-word-block .jelyk-meaning-gloss{margin:0 0 .75rem 0;font-size:1.05em}
+.jelyk-word-block .jelyk-meaning-tr{display:none;margin:.1rem 0 .6rem 0;font-size:1.02em;opacity:.92}
+.jelyk-word-block .jelyk-hr{border:0;border-top:1px solid rgba(0,0,0,.12);margin:.75rem 0 1rem 0}
+.jelyk-word-block .jelyk-row{margin:0 0 1rem 0}
+.jelyk-word-block .jelyk-row-title{font-weight:700;margin:0 0 .35rem 0}
+.jelyk-word-block .jelyk-tokens{display:flex;flex-wrap:wrap;gap:.35rem .45rem}
+.jelyk-word-block .jelyk-token{display:inline-flex;align-items:center;padding:.18rem .5rem;border:1px solid rgba(0,0,0,.15);border-radius:.4rem;text-decoration:none;line-height:1.2}
+.jelyk-word-block .jelyk-token:hover{text-decoration:none;border-color:rgba(0,0,0,.3)}
+.jelyk-word-block .jelyk-token--plain{cursor:default}
+.jelyk-word-block .jelyk-cards-title{font-weight:700;margin:0 0 .65rem 0}
+.jelyk-word-block .jelyk-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:1rem}
+.jelyk-word-block .jelyk-card{background:#fff;border:1px solid rgba(0,0,0,.12);border-radius:.6rem;overflow:hidden}
+.jelyk-word-block .jelyk-card figure{margin:0}
+.jelyk-word-block .jelyk-card img{width:100%;height:auto;display:block}
+.jelyk-word-block .jelyk-card-body{padding:.75rem .85rem}
+.jelyk-word-block .jelyk-card-de{margin:0;font-weight:600}
+.jelyk-word-block .jelyk-card-tr-wrap{margin:.45rem 0 0 0;font-size:.95em;opacity:.9}
+.jelyk-word-block .jelyk-card-tr{display:none;margin:0}
+.jelyk-word-block .jelyk-note{margin:.25rem 0 0 0;opacity:.85}
 CSS;
+
+        if ( defined( 'JELYK_DEBUG_CSS' ) && JELYK_DEBUG_CSS ) {
+            self::debug_check_frontend_css_scope( $css );
+        }
         wp_add_inline_style( 'jelyk-word-frontend', $css );
 
         // Tiny JS: language switcher for card translations (no reload).
@@ -1161,6 +1170,26 @@ CSS;
 })();
 JS;
         wp_add_inline_script( 'jelyk-word-frontend', $js );
+    }
+
+    protected static function debug_check_frontend_css_scope( $css ) {
+        $patterns = [
+            '/(?:^|\n)\s*html\s*[,\{]/i',
+            '/(?:^|\n)\s*body\s*[,\{]/i',
+            '/(?:^|\n)\s*\*\s*[,\{]/',
+            '/(?:^|\n)\s*p\s*\{/',
+            '/(?:^|\n)\s*h[1-6]\s*\{/',
+            '/(?:^|\n)\s*img\s*\{/',
+            '/(?:^|\n)\s*a\s*\{/',
+            '/(?:^|\n)\s*(ul|ol|li|figure|table|input|select|textarea)\s*\{/',
+        ];
+
+        foreach ( $patterns as $pattern ) {
+            if ( preg_match( $pattern, (string) $css ) ) {
+                error_log( 'Jelyk Word Plugin: Possible unscoped frontend CSS selector detected.' );
+                return;
+            }
+        }
     }
 
     public static function append_frontend_output( $content ) {


### PR DESCRIPTION
### Motivation
- The plugin emitted global/unscoped CSS which leaked into the active WP theme and altered styles outside the plugin block.
- The frontend output is wrapped in a `.jelyk-word-block` container and all plugin styles must be confined to that scope to avoid theme impact.
- Ensure admin styles are also limited to the plugin metabox and frontend assets are only enqueued when needed.

### Description
- Restrict frontend enqueueing to the queried single post that actually has Jelyk meanings by checking `is_singular('post')` and `post_has_meanings()` before registering/enqueuing assets in `frontend_assets()` in `jelyk-word-plugin.php`.
- Harden inline frontend CSS by prefixing every selector with `.jelyk-word-block` so no selectors apply globally (updated inline CSS in `jelyk-word-plugin.php`).
- Scope admin/editor styles under the metabox container `#jelyk_meanings_cards` in `assets/jelyk-word-admin.css` so admin CSS does not bleed into other admin pages.
- Add an optional dev-only CSS guard `debug_check_frontend_css_scope()` enabled via the `JELYK_DEBUG_CSS` constant that scans the inline CSS for suspicious unscoped selectors and logs a warning to `error_log` if found.
- Files changed: `jelyk-word-plugin.php`, `assets/jelyk-word-admin.css`.
- Closes #3

### Testing
- Ran `php -l jelyk-word-plugin.php` and syntax check passed.
- Searched for unscoped/global selectors with `rg` against plugin files and confirmed inline frontend CSS is rooted under `.jelyk-word-block` and admin CSS is scoped under `#jelyk_meanings_cards` (searches returned no remaining global frontend selectors).
- Verified admin asset loading remains limited to post editor screens via existing `enqueue_admin_assets()` checks during code inspection.
- Attempted a Playwright screenshot to validate page-level rendering but the local web endpoint was unreachable (`ERR_EMPTY_RESPONSE`), so visual QA was not performed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69933826ce3c832ea361fef8f59a44c4)